### PR TITLE
Update legacy variable substitution syntax deprecated in ansible 1.2

### DIFF
--- a/roles/timezone/tasks/main.yml
+++ b/roles/timezone/tasks/main.yml
@@ -4,10 +4,10 @@
   file: path=/etc/localtime state=absent
 
 - name: Timezone | Symlink the correct localtime - pt.2 (/etc/localtime)
-  file: src=/usr/share/zoneinfo/$timezone dest=/etc/localtime state=link owner=root group=root mode=0644
+  file: src=/usr/share/zoneinfo/{{ timezone }} dest=/etc/localtime state=link owner=root group=root mode=0644
 
 - name: Timezone | Make sure the dependencies are installed
-  apt: pkg=$item
+  apt: name={{ item }} state=installed
   with_items:
     - tzdata
     - ntp


### PR DESCRIPTION
Using the-ansibles with Ansible 1.4+ results in deprecated syntax warnings – unless you've turned off the warnings! – due to old style variable substitution syntax being used. I note that several roles use the old style syntax and I'm updating them as I use them.

This pull request is only for the timezone role. Let me know if you'd like a bunch of the fixed roles in one pull request instead of a pull request per roll...
