### PR TITLE
Fix ferm handler name

### DIFF
--- a/roles/firewall/handlers/ferm.yml
+++ b/roles/firewall/handlers/ferm.yml
@@ -1,4 +1,0 @@
-# file: roles/firewall/handlers/ferm.yml
-
-- name: reload ferm
-  command: /etc/init.d/ferm reload


### PR DESCRIPTION
Testing cloudbox I saw an error with the ferm handler:

```
ERROR: change handler (reload ferm) is not defined
```

Which seemed to be due to the misnaming of the handler file, so, pull request.
