### PR TITLE
Remove legacy variable templating

### DIFF
--- a/roles/auth/tasks/users.yml
+++ b/roles/auth/tasks/users.yml
@@ -2,4 +2,4 @@
 
 - name: Auth | Make sure the users are present
   user: name={{ item.name }} uid={{ item.uid }} password={{ item.passwd }} shell={{ item.shell }} comment="{{ item.comment }}" groups={{ ",".join(item.groups) }} append={{ item.append }}
-  with_items: $users
+  with_items: users

--- a/roles/directories/tasks/main.yml
+++ b/roles/directories/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Directories | Make sure all default directories are present
   file: path={{item.path}} state=directory owner={{item.owner}} group={{item.group}} mode={{item.mode}}
-  with_items: $directories_default
+  with_items: directories_default
 
 - name: Directories | Make sure all additional directories are present
   file: path={{item.path}} state=directory owner={{item.owner}} group={{item.group}} mode={{item.mode}}
-  with_items: $directories_additional
+  with_items: directories_additional


### PR DESCRIPTION
The `$var` syntax has been deprecated in ansible 1.6. This updates the roles that used this syntax.
