### PR TITLE
Theres no package called ack in Ubuntu(debian linux), so I changed it to ack-grep.

### DIFF
--- a/roles/build/tasks/main.yml
+++ b/roles/build/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Build | Make sure essential build/dev tools and compilers are installed/up-to-date
   apt: pkg={{ item }}
   with_items:
-    - ack
+    - ack-grep
     - acl
     - apticron
     - automake


### PR DESCRIPTION
In debian to install ack the package names is called `"ack-grep"`` . This PR fixes that issue with installing it on Debian. 
